### PR TITLE
Fixed twitter links

### DIFF
--- a/index.html
+++ b/index.html
@@ -740,7 +740,7 @@
               class="fab fa-github"
             ></a>
             <a
-              href="https://twitter.com/evavic44"
+              href="https://twitter.com/victorekea"
               title="Twitter"
               target="_blank"
               class="fab fa-twitter"
@@ -828,7 +828,7 @@
         <div class="footer-container">
           <div class="social">
             <div>
-              <a href="http://twitter.com/evavic44">
+              <a href="https://twitter.com/victorekea">
                 <img
                   src="https://img.shields.io/twitter/follow/evavic44?label=Twitter&logo=twitter&style=for-the-badge" alt="Twitter badge"
                 />


### PR DESCRIPTION
Previous twitter links were redirecting to `http://twitter.com/evavic44`. Now they properly redirect to `https://twitter.com/victorekea` as they should.